### PR TITLE
Move e-mail style to a separate file

### DIFF
--- a/app/presenters/TeamPresenter.php
+++ b/app/presenters/TeamPresenter.php
@@ -386,8 +386,13 @@ class TeamPresenter extends BasePresenter {
 				$mtemplate->password = $password;
 				$mtemplate->invoice = $invoice;
 				$mtemplate->organiserMail = $this->context->parameters['webmasterEmail'];
+				$emogrifier = new \Pelago\Emogrifier();
+				$emogrifier->setHtml($mtemplate);
+				$emogrifier->setCss(file_get_contents($appDir . '/templates/Mail/style.css'));
+				$emogrifier->enableCssToHtmlMapping();
+
 				$mail = new Message();
-				$mail->setFrom($mtemplate->organiserMail)->addTo($address)->setHtmlBody($mtemplate);
+				$mail->setFrom($mtemplate->organiserMail)->addTo($address)->setHtmlBody($emogrifier->emogrify());
 
 				$mailer = $this->context->getByType('Nette\Mail\IMailer');
 				$mailer->send($mail);

--- a/app/templates/Mail/style.css
+++ b/app/templates/Mail/style.css
@@ -1,0 +1,34 @@
+body {
+	font: 16px/1.5 'Trebuchet MS', 'Geneva CE', lucida, sans-serif !important;
+	color: #333333 !important;
+}
+h1 {
+	font-size: 150%;
+	color: #3484d2;
+	margin: 0.2em 0 0.3em;
+}
+h2 {
+	margin: 0.2em 0 0.3em;
+}
+table {
+	border-collapse: collapse;
+	min-width: 30%;
+	margin: 0.5em 0;
+	border: 0.25em solid #333333;
+}
+tr:nth-child(odd) {
+	background-color: #eeeeee;
+}
+tr:nth-child(even) {
+	background-color: #ffffff;
+}
+th {
+	color: #ffffff;
+	text-align: left;
+	background-color: #3484d2;
+	padding: 0.25em 0.5em 0.5em 0.8em;
+}
+a, a:hover, a:active. a:focus {
+	color: #006aeb !important;
+	padding: 3px 1px;
+}

--- a/app/templates/Mail/verification.cs.latte
+++ b/app/templates/Mail/verification.cs.latte
@@ -4,38 +4,32 @@
 <title>MČR 2012 – Potvrzení registrace</title>
 </head>
 <body>
-<h1 style="font-size: 150%; color: #3484d2; margin: 0.2em 0 0.3em;">Mistrovství republiky v rogainingu 2012</h1>
-<h2 style="margin: 0.2em 0 0.3em;">Potvrzení registrace</h2>
+<h1>Mistrovství republiky v rogainingu 2012</h1>
+<h2>Potvrzení registrace</h2>
 <p>Vážený závodníku,</p>
-<p>děkujeme za zaslání přihlášky. Registrační ID Vašeho týmu je {$id}. Prosím, uschovejte si je. Poslouží k identifikaci vašeho týmu při případné editaci vaší přihlášky a komunikaci s pořadateli závodu. Prosíme, abyste si v <a href="{link //Team:list}" style="color: #006aeb; padding: 3px 1px;">seznamu přihlášek</a> zkontrolovali správnost registračních údajů.
+<p>děkujeme za zaslání přihlášky. Registrační ID Vašeho týmu je {$id}. Prosím, uschovejte si je. Poslouží k identifikaci vašeho týmu při případné editaci vaší přihlášky a komunikaci s pořadateli závodu. Prosíme, abyste si v <a href="{link //Team:list}">seznamu přihlášek</a> zkontrolovali správnost registračních údajů.
 <p>Vaši přihlášku můžete editovat pomocí ID a hesla, které naleznete níže.</p>
 <p>Po zaplacení částky <strong>{$invoice->getTotal()},–</strong> (startovné + ubytování + příp. půjčovné čipu) s variabilním symbolem <strong>{$id}</strong> na účet číslo <strong>670100-2200554162/6210</strong> bude přihláška plně akceptována.</p>
-<p>V případě jakýchkoli problémů s přihláškou pište na e-mail: <a href="mailto:{$organiserMail}" style="color: #006aeb; padding: 3px 1px;">{$organiserMail}</a>.
+<p>V případě jakýchkoli problémů s přihláškou pište na e-mail: <a href="mailto:{$organiserMail}">{$organiserMail}</a>.
 
 <h3>Detaily přihlášky:</h3>
 <h4>Tým</h4>
-<table class="teamlist" style="border-collapse: collapse; min-width: 30%; margin: 0.5em 0; border: 0.25em solid #333333;">
-<tr style="background-color: #eeeeee;" bgcolor="#eeeeee"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Registrační ID:</th><td>{$id}</td></tr>
-<tr style="background-color: #ffffff;" bgcolor="#ffffff"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Název týmu:</th><td>{$team->name}</td></tr>
-<tr style="background-color: #eeeeee;" bgcolor="#eeeeee"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Heslo:</th><td>{$password}</td></tr>
-<tr style="background-color: #ffffff;" bgcolor="#ffffff"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Kategorie:</th><td>{$team|categoryFormat}</td></tr>
-<tr style="background-color: #eeeeee;" bgcolor="#eeeeee"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Zpráva:</th><td>{$team->message}</td></tr>
+<table class="teamlist">
+<tr><th>Registrační ID:</th><td>{$id}</td></tr>
+<tr><th>Název týmu:</th><td>{$team->name}</td></tr>
+<tr><th>Heslo:</th><td>{$password}</td></tr>
+<tr><th>Kategorie:</th><td>{$team|categoryFormat}</td></tr>
+<tr><th>Zpráva:</th><td>{$team->message}</td></tr>
 </table>
 {foreach $people as $person}
 <h4>{$iterator->counter}. člen týmu{if $person->contact} {_messages.team.person.isContact}{/if}</h4>
-<table class="teamlist" style="border-collapse: collapse; min-width: 30%; margin: 0.5em 0; border: 0.25em solid #333333;">
-<tr style="background-color: #ffffff;" bgcolor="#ffffff"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Jméno:</th><td>{$person->firstname} {$person->lastname}</td></tr>
-<tr style="background-color: #eeeeee;" bgcolor="#eeeeee"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Pohlaví:</th><td>{if $person->gender=='male'}♂ Muž{else}♀ Žena{/if}</td></tr>
-<tr style="background-color: #ffffff;" bgcolor="#ffffff"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Datum narození:</th><td>{$person->birth|date:'%-d. %-m. %Y'}</td></tr>
-<tr style="background-color: #ffffff;" bgcolor="#ffffff" n:if="$person->email"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">E-Mail:</th><td>{$person->email}</td></tr>
+<table class="teamlist">
+<tr><th>Jméno:</th><td>{$person->firstname} {$person->lastname}</td></tr>
+<tr><th>Pohlaví:</th><td>{if $person->gender=='male'}♂ Muž{else}♀ Žena{/if}</td></tr>
+<tr><th>Datum narození:</th><td>{$person->birth|date:'%-d. %-m. %Y'}</td></tr>
+<tr n:if="$person->email"><th>E-Mail:</th><td>{$person->email}</td></tr>
 </table>
 {/foreach} <br>
 <p>Prosím, uschovejte tento mail pro případnou budoucí komunikaci.</p>
-<style type="text/css">
-.body { font: 16px/1.5 "Trebuchet MS", "Geneva CE", lucida, sans-serif !important; color: #333333 !important;}
-a:hover { background-color: #006aeb !important; color: #ffffff !important; text-decoration: none !important; }
-a:active { background-color: #006aeb !important; color: #ffffff !important; text-decoration: none !important; }
-a:focus { background-color: #006aeb !important; color: #ffffff !important; text-decoration: none !important; }
-</style>
 </body>
 </html>

--- a/app/templates/Mail/verification.latte
+++ b/app/templates/Mail/verification.latte
@@ -4,37 +4,31 @@
 <title>CRC 2012 – Registration Acknowledgement</title>
 </head>
 <body>
-<h1 style="font-size: 150%; color: #3484d2; margin: 0.2em 0 0.3em;">The Czech Rogaining Championships 2012</h1>
-<h2 style="margin: 0.2em 0 0.3em;">Registration Acknowledgement</h2>
+<h1>The Czech Rogaining Championships 2012</h1>
+<h2>Registration Acknowledgement</h2>
 <p>Hello {$name},</p>
-<p>thank you for your registration. Your registration ID is {$id}. Please remember it. It will identify your team in the processing of entries and any other correspondence that is necessary. Consult the <a href="{link //Team:list}" style="color: #006aeb; padding: 3px 1px;">list of entrants</a> on the CRC website to check whether your registration data are correct. You can edit your entry using password provided bellow.	Fees (starting fee, SI card hire fee, accommodation) <strong>{$invoice->getTotal()},–</strong> CZK pay cash at registration. You can also pay in EUR.</p>
+<p>thank you for your registration. Your registration ID is {$id}. Please remember it. It will identify your team in the processing of entries and any other correspondence that is necessary. Consult the <a href="{link //Team:list}">list of entrants</a> on the CRC website to check whether your registration data are correct. You can edit your entry using password provided bellow.	Fees (starting fee, SI card hire fee, accommodation) <strong>{$invoice->getTotal()},–</strong> CZK pay cash at registration. You can also pay in EUR.</p>
 
-<p>If you have any queries about your entry please e-mail <a href="mailto:{$organiserMail}" style="color: #006aeb; padding: 3px 1px;">{$organiserMail}</a>.</p>
+<p>If you have any queries about your entry please e-mail <a href="mailto:{$organiserMail}">{$organiserMail}</a>.</p>
 
 <h3>Entry details:</h3>
 <h4>Team</h4>
-<table class="teamlist" style="border-collapse: collapse; min-width: 30%; margin: 0.5em 0; border: 0.25em solid #333333;">
-<tr style="background-color: #eeeeee;" bgcolor="#eeeeee"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Registration ID:</th><td>{$id}</td></tr>
-<tr style="background-color: #ffffff;" bgcolor="#ffffff"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Team name:</th><td>{$team->name}</td></tr>
-<tr style="background-color: #eeeeee;" bgcolor="#eeeeee"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Password:</th><td>{$password}</td></tr>
-<tr style="background-color: #ffffff;" bgcolor="#ffffff"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Team category:</th><td>{$team|categoryFormat}</td></tr>
-<tr style="background-color: #eeeeee;" bgcolor="#eeeeee"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Message:</th><td>{$team->message}</td></tr>
+<table class="teamlist">
+<tr><th>Registration ID:</th><td>{$id}</td></tr>
+<tr><th>Team name:</th><td>{$team->name}</td></tr>
+<tr><th>Password:</th><td>{$password}</td></tr>
+<tr><th>Team category:</th><td>{$team|categoryFormat}</td></tr>
+<tr><th>Message:</th><td>{$team->message}</td></tr>
 </table>
 {foreach $people as $person}
 <h4>Team member {$iterator->counter}{if $person->contact} {_messages.team.person.isContact}{/if}</h4>
-<table class="teamlist" style="border-collapse: collapse; min-width: 30%; margin: 0.5em 0; border: 0.25em solid #333333;">
-<tr style="background-color: #ffffff;" bgcolor="#ffffff"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Name:</th><td>{$person->firstname} {$person->lastname}</td></tr>
-<tr style="background-color: #eeeeee;" bgcolor="#eeeeee"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Gender:</th><td>{if $person->gender=='male'}♂ Male{else}♀ Female{/if}</td></tr>
-<tr style="background-color: #ffffff;" bgcolor="#ffffff"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">Date of birth:</th><td>{$person->birth|date:'%b/%d/%Y'}</td></tr>
-<tr style="background-color: #ffffff;" bgcolor="#ffffff" n:if="$person->email"><th style="color: #ffffff; text-align: left; background-color: #3484d2; padding: 0.25em 0.5em 0.5em 0.8em;" align="left" bgcolor="#3484d2">E-Mail address:</th><td>{$person->email}</td></tr>
+<table class="teamlist">
+<tr><th>Name:</th><td>{$person->firstname} {$person->lastname}</td></tr>
+<tr><th>Gender:</th><td>{if $person->gender=='male'}♂ Male{else}♀ Female{/if}</td></tr>
+<tr><th>Date of birth:</th><td>{$person->birth|date:'%b/%d/%Y'}</td></tr>
+<tr n:if="$person->email"><th>E-Mail address:</th><td>{$person->email}</td></tr>
 </table>
 {/foreach}
  <br><p>Please archive this message for future communication.</p>
-<style type="text/css">
-.body { font: 16px/1.5 "Trebuchet MS", "Geneva CE", lucida, sans-serif !important; color: #333333 !important;}
-a:hover { background-color: #006aeb !important; color: #ffffff !important; text-decoration: none !important; }
-a:active { background-color: #006aeb !important; color: #ffffff !important; text-decoration: none !important; }
-a:focus { background-color: #006aeb !important; color: #ffffff !important; text-decoration: none !important; }
-</style>
 </body>
 </html>

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
 		"nextras/forms": "dev-master",
 		"kdyby/forms-replicator": "dev-master",
 		"kdyby/translation": "dev-master",
-		"nextras/orm": "@dev"
+		"nextras/orm": "@dev",
+		"pelago/emogrifier": "^1.2"
 	},
 	"require-dev": {
 		"friendsofphp/php-cs-fixer": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "4911cf1b93087475f7b474ca66269b0a",
+    "content-hash": "b02b0bfac75209dabcf3901ef8e0cd49",
     "packages": [
         {
             "name": "kdyby/forms-replicator",
@@ -1550,6 +1550,66 @@
                 "orm"
             ],
             "time": "2017-02-19 22:29:06"
+        },
+        {
+            "name": "pelago/emogrifier",
+            "version": "V1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jjriv/emogrifier.git",
+                "reference": "a1db453bb504597d821efcc04b21c79a6021e00c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jjriv/emogrifier/zipball/a1db453bb504597d821efcc04b21c79a6021e00c",
+                "reference": "a1db453bb504597d821efcc04b21c79a6021e00c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0,<=7.1.99"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.8.27",
+                "squizlabs/php_codesniffer": "2.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pelago\\": "Classes/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Reeve",
+                    "email": "jreeve@pelagodesign.com"
+                },
+                {
+                    "name": "Cameron Brooks"
+                },
+                {
+                    "name": "Jaime Prado"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "typo3-coding@oliverklee.de"
+                },
+                {
+                    "name": "Roman Ožana",
+                    "email": "ozana@omdesign.cz"
+                }
+            ],
+            "description": "Converts CSS styles into inline style attributes in your HTML code",
+            "homepage": "http://www.pelagodesign.com/sidecar/emogrifier/",
+            "time": "2017-03-02T12:51:48+00:00"
         },
         {
             "name": "psr/log",


### PR DESCRIPTION
Inline CSS inside the e-mail templates is tedious – the templates are too cluttered, the CSS needs to be synchronized between elements and templates, adding or removing a table row means adjusting the styles of all the rows below and there is also the issue of CSS support in e-mail clients.

Using the emogrifier will make maintaining the templates easier.