### PR TITLE
Add support for category specific fields

### DIFF
--- a/app/components/TeamForm.php
+++ b/app/components/TeamForm.php
@@ -10,6 +10,7 @@ use Nette\Forms\Controls\SubmitButton;
 use Nette\Forms\Form;
 use Nette\Utils\Callback;
 use Nette\Utils\Html;
+use Nette\Utils\Json;
 
 class TeamForm extends UI\Form {
 	/** @var array */
@@ -158,6 +159,10 @@ class TeamForm extends UI\Form {
 
 				if (isset($field['description'])) {
 					$input->setOption('description', $field['description'][$locale]);
+				}
+
+				if (isset($field['applicableCategories'])) {
+					$input->getControlPrototype()->{'data-applicable-categories'} = Json::encode($field['applicableCategories']);
 				}
 			}
 		}

--- a/app/presenters/TeamPresenter.php
+++ b/app/presenters/TeamPresenter.php
@@ -223,6 +223,8 @@ class TeamPresenter extends BasePresenter {
 		/** @var string $password */
 		$password = null;
 
+		$this->cleanNonApplicableFields($form);
+
 		if ($this->action === 'edit') {
 			$id = (int) $this->getParameter('id');
 			$team = $this->teams->getById($id);
@@ -409,6 +411,26 @@ class TeamPresenter extends BasePresenter {
 				$form->addError('messages.team.error.edit_general');
 			} else {
 				$form->addError('messages.team.error.add_general');
+			}
+		}
+	}
+
+	public function cleanNonApplicableFields(Nette\Forms\Form $form) {
+		$category = $form['category']->getValue();
+
+		$teamFields = $this->presenter->context->parameters['entries']['fields']['team'];
+		foreach ($teamFields as $name => $field) {
+			if (isset($field['applicableCategories']) && !in_array($category, $field['applicableCategories'], true)) {
+				$form[$name]->setValue(null);
+			}
+		}
+
+		$personFields = $this->presenter->context->parameters['entries']['fields']['person'];
+		foreach ($form['persons']->values as $member) {
+			foreach ($personFields as $name => $field) {
+				if (isset($field['applicableCategories']) && !in_array($category, $field['applicableCategories'], true)) {
+					$form['persons'][$name]->setValue(null);
+				}
 			}
 		}
 	}

--- a/app/templates/Team/edit.latte
+++ b/app/templates/Team/edit.latte
@@ -2,3 +2,6 @@
 
 {block content}
 {control teamForm}
+{/block}
+{block scripts}
+<script src="{$basePath}/js/form.js"></script>

--- a/app/templates/Team/register.latte
+++ b/app/templates/Team/register.latte
@@ -2,3 +2,6 @@
 
 {block content}
 {control teamForm}
+{/block}
+{block scripts}
+<script src="{$basePath}/js/form.js"></script>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,6 +170,7 @@ fields:
 * `type` – Each field will need to declare its type, see [field types](#field-types).
 * `label` – Some fields may define a default label (`sportident`, `country`) but otherwise you should define one for each language.
 * `private` – By default, the value of every will be displayed at the team list publicly. You can set it to `false` to prevent leaking personal information or items only relevant for organizers.
+* `applicableCategories` – A list of categories to show this field in. If not present, every category is implied.
 
 ###### Field types
 

--- a/www/js/form.js
+++ b/www/js/form.js
@@ -1,0 +1,25 @@
+$(function(){
+	var conditionalFields = [];
+	$('[data-applicable-categories]').each(function() {
+		conditionalFields.push([
+			$(this).parents('.form-group'),
+			JSON.parse(this.getAttribute('data-applicable-categories'))
+		]);
+	});
+
+	var categoryField = $('#frm-teamForm-category');
+
+	function categoryChanged() {
+		var category = categoryField.val();
+		$.each(conditionalFields, function() {
+			if (this[1].indexOf(category) === -1) {
+				$(this[0]).hide();
+			} else {
+				$(this[0]).show();
+			}
+		});
+	};
+
+	categoryField.change(categoryChanged);
+	categoryChanged();
+});


### PR DESCRIPTION
Some fields are only applicable to a subset of the categories. This commit hides the irrelevant fields using JavaScript and filters them out on the server side.