### PR TITLE
teamform: Switch to contributte/multiplier

### DIFF
--- a/app/components/TeamForm.php
+++ b/app/components/TeamForm.php
@@ -6,7 +6,6 @@ namespace App\Components;
 
 use Contributte\Translation\Wrappers\NotTranslate;
 use Nette\Application\UI;
-use Nette\ComponentModel\IContainer;
 use Nette\Forms\Container;
 use Nette\Forms\Controls;
 use Nette\Utils\Json;
@@ -24,31 +23,11 @@ class TeamForm extends UI\Form {
 	/** @var string */
 	private $locale;
 
-	public function __construct(array $countries, array $parameters, string $locale, IContainer $parent = null, string $name = null) {
-		parent::__construct($parent, $name);
+	public function __construct(array $countries, array $parameters, string $locale) {
+		parent::__construct();
 		$this->countries = $countries;
 		$this->parameters = $parameters;
 		$this->locale = $locale;
-	}
-
-	public function onRender(): void {
-		/** @var \Kdyby\Replicator\Container */
-		$persons = $this['persons'];
-		$count = iterator_count($persons->getContainers());
-		$minMembers = $this->parameters['minMembers'];
-		$maxMembers = $this->parameters['maxMembers'];
-
-		if ($count >= $maxMembers) {
-			/** @var Controls\SubmitButton */
-			$add = $this['add'];
-			$add->setDisabled();
-		}
-
-		if ($count <= $minMembers) {
-			/** @var Controls\SubmitButton */
-			$remove = $this['remove'];
-			$remove->setDisabled();
-		}
 	}
 
 	public function addCustomFields(array $fields, Container $container): void {

--- a/app/config/CustomInputModifier.php
+++ b/app/config/CustomInputModifier.php
@@ -16,14 +16,16 @@ class CustomInputModifier {
 	public static function modify(Control $input, IContainer $container): void {
 		// we also have some inputs that are based on Nextras\FormComponents\Fragments\UIComponent\BaseControl
 		if ($input instanceof BaseControl && $input->getName() === 'registry_address') {
-			$pairId = 'pair-' . $input->htmlId;
-			$input->setOption('id', $pairId);
+			$input->monitor(Form::class, function(Form $form) use ($input, $container): void {
+				$pairId = 'pair-' . $input->htmlId;
+				$input->setOption('id', $pairId);
 
-			/** @var BaseControl */
-			$country = $container->getComponent('country');
-			$country->addCondition(Form::NOT_EQUAL, 46)->toggle($pairId, false);
-			$input->setRequired(false);
-			$input->addConditionOn($country, Form::EQUAL, 46)->setRequired();
+				/** @var BaseControl */
+				$country = $container->getComponent('country');
+				$country->addCondition(Form::NOT_EQUAL, 46)->toggle($pairId, false);
+				$input->setRequired(false);
+				$input->addConditionOn($country, Form::EQUAL, 46)->setRequired();
+			});
 		}
 	}
 }

--- a/app/config/config.neon
+++ b/app/config/config.neon
@@ -38,7 +38,7 @@ extensions:
 	translation: Contributte\Translation\DI\TranslationExtension
 	orm: Nextras\Orm\Bridges\NetteDI\OrmExtension
 	dbal: Nextras\Dbal\Bridges\NetteDI\DbalExtension
-	replicator: Kdyby\Replicator\DI\ReplicatorExtension
+	multiplier: Contributte\FormMultiplier\DI\MultiplierExtension
 	contribMail: Contributte\Mail\DI\MailExtension
 
 contribMail:

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
 	],
 	"require": {
 		"php": ">= 8.0",
+		"contributte/forms-multiplier": "^3.2",
 		"contributte/mail": "^0.6.0",
 		"contributte/translation": "^1.0",
 		"ihor/nspl": "^1.3",
-		"kdyby/forms-replicator": "^2.0.0",
 		"latte/latte": "~2.5",
 		"moneyphp/money": "^4.0",
 		"nette/application": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,74 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1156fad39db1ce5defb7ca4a10c0fce9",
+    "content-hash": "28791aec1018df56fa77984d8b50f1ec",
     "packages": [
+        {
+            "name": "contributte/forms-multiplier",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/contributte/forms-multiplier.git",
+                "reference": "5bafb566431294220f7723616d8417cc631d0a43"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/contributte/forms-multiplier/zipball/5bafb566431294220f7723616d8417cc631d0a43",
+                "reference": "5bafb566431294220f7723616d8417cc631d0a43",
+                "shasum": ""
+            },
+            "require": {
+                "nette/forms": "^3.1.0",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "codeception/codeception": "^4.0.0",
+                "codeception/module-asserts": "^1.3",
+                "codeception/module-phpbrowser": "^1.0",
+                "latte/latte": "^3.0.0",
+                "nette/application": "^3.0.0",
+                "nette/di": "^3.0.0",
+                "ninjify/qa": "^0.12",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-nette": "^1.0",
+                "webchemistry/testing-helpers": "~2.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Contributte\\FormMultiplier\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "description": "Multiplier for nette forms",
+            "keywords": [
+                "Forms",
+                "contributte",
+                "multiplier",
+                "nette"
+            ],
+            "support": {
+                "issues": "https://github.com/contributte/forms-multiplier/issues",
+                "source": "https://github.com/contributte/forms-multiplier/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://contributte.org/partners.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/f3l1x",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-08-05T10:06:02+00:00"
+        },
         {
             "name": "contributte/mail",
             "version": "v0.6.0",
@@ -230,79 +296,6 @@
                 "source": "https://github.com/ihor/NSPL/tree/master"
             },
             "time": "2019-03-21T20:38:30+00:00"
-        },
-        {
-            "name": "kdyby/forms-replicator",
-            "version": "v2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Kdyby/FormsReplicator.git",
-                "reference": "cd6c9ccfaade43b85d181a8041ec5a7f842969b1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Kdyby/FormsReplicator/zipball/cd6c9ccfaade43b85d181a8041ec5a7f842969b1",
-                "reference": "cd6c9ccfaade43b85d181a8041ec5a7f842969b1",
-                "shasum": ""
-            },
-            "require": {
-                "nette/forms": "^3.0",
-                "nette/utils": "^3.0",
-                "php": ">=7.1"
-            },
-            "require-dev": {
-                "nette/application": "^3.0@rc",
-                "nette/bootstrap": "^3.0@rc",
-                "nette/di": "^3.0@rc",
-                "nette/tester": "^2.2",
-                "tracy/tracy": "^2.6"
-            },
-            "suggest": {
-                "nette/di": "to use ReplicatorExtension[CompilerExtension]"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Kdyby\\Replicator\\": "src/Replicator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause",
-                "GPL-2.0",
-                "GPL-3.0"
-            ],
-            "authors": [
-                {
-                    "name": "Filip Procházka",
-                    "email": "filip@prochazka.su",
-                    "homepage": "http://filip-prochazka.com"
-                },
-                {
-                    "name": "David Šolc",
-                    "email": "solcik@gmail.com",
-                    "homepage": "https://solc.dev"
-                }
-            ],
-            "description": "Nette forms container replicator aka addDynamic",
-            "homepage": "http://kdyby.org",
-            "keywords": [
-                "Forms",
-                "addDynamic",
-                "kdyby",
-                "nette",
-                "replicator"
-            ],
-            "support": {
-                "issues": "https://github.com/Kdyby/FormsReplicator/issues",
-                "source": "https://github.com/Kdyby/FormsReplicator/tree/master"
-            },
-            "time": "2019-03-18T16:16:28+00:00"
         },
         {
             "name": "latte/latte",

--- a/utils/phpstan.neon
+++ b/utils/phpstan.neon
@@ -12,4 +12,4 @@ parameters:
 	treatPhpDocTypesAsCertain: false
 	checkGenericClassInNonGenericObjectType: false
 	ignoreErrors:
-		- '(Call to an undefined method App\\Components\\TeamForm::addDynamic\(\))'
+		- '(Call to an undefined method App\\Components\\TeamForm::addMultiplier\(\))'


### PR DESCRIPTION
`kdyby/replicator` served us well for a long time but unfortunately, it has been unmaintained for a while now. Let’s switch to an actively maintained library.

Multiplier manages adding and removing for us and handles default values correctly.

The switch also allowed us to remove the outdated explicit anchoring by passing parent and name in constructor, letting Nette handle it. A disadvantage is the inability to access stuff like `htmlId`/`isSubmitted()` without being anchored – but that can be solved by using `monitor()`.

Currently, we cannot control per-category person limits at submission: https://github.com/contributte/forms-multiplier/issues/75