### PR TITLE
Support self-contained translations

### DIFF
--- a/app/Components/CategoryEntry.php
+++ b/app/Components/CategoryEntry.php
@@ -6,33 +6,40 @@ namespace App\Components;
 
 use App\Model\CategoryData;
 use Contributte\Translation\Wrappers\NotTranslate;
-use Nette;
 
 /**
  * Input field for choosing team category.
  * It can be used for either editing team category or filtering
  * teams by category.
  */
-final class CategoryEntry extends Nette\Forms\Controls\SelectBox {
+final class CategoryEntry extends ObjectSelectBox {
 	/**
 	 * @param string $label label of the field
 	 * @param CategoryData $categories categories defined in the configuration
 	 * @param bool $showAll when in filtering mode, it is useful to add “All” option as a “const true” filter
 	 */
 	public function __construct(string $label, CategoryData $categories, bool $showAll = false) {
+		$categoryTree = $categories->getCategoryTree();
 		if ($categories->areNested()) {
-			$items = array_map(function($group) use ($showAll) {
-				$categoryArray = array_map([self::class, 'labelKey'], $group);
+			$items = array_map(
+				function(string $groupKey, array $group) use ($showAll): OptGroup {
+					$categoryArray = array_map(self::labelKey(...), $group);
 
-				if ($showAll) {
-					$allKey = implode('|', array_keys($group));
-					$categoryArray = [$allKey => 'messages.team.list.filter.category.all'] + $categoryArray;
-				}
+					if ($showAll) {
+						$allKey = implode('|', array_keys($group));
+						$categoryArray = [$allKey => 'messages.team.list.filter.category.all'] + $categoryArray;
+					}
 
-				return $categoryArray;
-			}, $categories->getCategoryTree());
+					return new OptGroup(
+						label: new NotTranslate($groupKey),
+						options: $categoryArray,
+					);
+				},
+				array_keys($categoryTree),
+				array_values($categoryTree)
+			);
 		} else {
-			$items = array_map([self::class, 'labelKey'], $categories->getCategoryTree());
+			$items = array_map(self::labelKey(...), $categoryTree);
 		}
 
 		parent::__construct($label, $items);

--- a/app/Components/ObjectSelectBox.php
+++ b/app/Components/ObjectSelectBox.php
@@ -1,0 +1,146 @@
+<?php
+
+// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: 2004 David Grudl
+// SPDX-FileCopyrightText: 2022 Jan Tojnar
+
+declare(strict_types=1);
+
+namespace App\Components;
+
+use App\Locale\Translated;
+use Contributte\Translation\Wrappers\NotTranslate;
+use Nette;
+use Nette\Forms\Controls;
+use Nette\Utils\Html;
+
+/**
+ * Select box control that allows single item selection.
+ * This is based on `Controls\SelectBox` but support non-string optgroup labels.
+ */
+class ObjectSelectBox extends Controls\ChoiceControl {
+	/** validation rule */
+	public const VALID = ':selectBoxValid';
+
+	/** @var array<string,string|Translated|NotTranslate>|array<OptGroup> */
+	private array $options = [];
+
+	private string|Translated|NotTranslate|false $prompt = false;
+
+	/** @var array<string, mixed> */
+	private array $optionAttributes = [];
+
+	/**
+	 * @param string|Translated $label
+	 * @param array<string,string|Translated|NotTranslate>|array<OptGroup> $items
+	 */
+	public function __construct($label = null, ?array $items = null) {
+		parent::__construct($label, $items);
+		$this->setOption('type', 'select');
+		$this->addCondition(function() {
+			return $this->prompt === false
+				&& $this->options
+				&& $this->control->size < 2;
+		})->addRule(Nette\Forms\Form::FILLED, Nette\Forms\Validator::$messages[self::VALID]);
+	}
+
+	/**
+	 * Sets first prompt item in select box.
+	 */
+	public function setPrompt(string|Translated|NotTranslate|false $prompt): static {
+		$this->prompt = $prompt;
+
+		return $this;
+	}
+
+	/**
+	 * Returns first prompt item?
+	 */
+	public function getPrompt(): string|Translated|NotTranslate|false {
+		return $this->prompt;
+	}
+
+	/**
+	 * Sets options and option groups from which to choose.
+	 *
+	 * @param array<string,string|Translated|NotTranslate>|array<OptGroup> $items
+	 */
+	public function setItems(array $items, bool $useKeys = null): static {
+		if ($useKeys !== null) {
+			throw new \InvalidArgumentException('useKeys argument is not supported.');
+		}
+
+		$this->options = $items;
+
+		$isNested = false;
+		foreach ($items as $item) {
+			$isNested = $item instanceof OptGroup;
+			break;
+		}
+		if ($isNested) {
+			/** @var OptGroup[] */
+			$nestedItems = $items;
+			$allItems = array_map(static fn(OptGroup $group): array => $group->options, $nestedItems);
+			$items = Nette\Utils\Arrays::flatten($allItems, preserveKeys: true);
+		}
+
+		return parent::setItems($items);
+	}
+
+	public function getControl(): Html {
+		$items = $this->prompt === false ? [] : ['' => $this->translate($this->prompt)];
+		foreach ($this->options as $key => $value) {
+			if ($value instanceof OptGroup) {
+				$items[$this->translate($value->label)] = $this->translate($value->options);
+			} else {
+				$items[$key] = $this->translate($value);
+			}
+		}
+
+		$control = parent::getControl();
+		\assert($control instanceof Html);
+
+		$select = Nette\Forms\Helpers::createSelectBox(
+			$items,
+			[
+				'disabled:' => \is_array($this->disabled) ? $this->disabled : null,
+			] + $this->optionAttributes,
+			$this->value
+		);
+		$select->addAttributes($control->attrs);
+		// Bs5FormRenderer would do it automatically for SelectBox
+		$select->addClass('form-select');
+
+		return $select;
+	}
+
+	/**
+	 * @param array<string, mixed> $attributes
+	 */
+	public function addOptionAttributes(array $attributes): static {
+		$this->optionAttributes = $attributes + $this->optionAttributes;
+
+		return $this;
+	}
+
+	public function setOptionAttribute(string $name, mixed $value = true): static {
+		$this->optionAttributes[$name] = $value;
+
+		return $this;
+	}
+
+	public function isOk(): bool {
+		return $this->isDisabled()
+			|| $this->prompt !== false
+			|| $this->getValue() !== null
+			|| !$this->options
+			|| $this->control->size > 1;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function getOptionAttributes(): array {
+		return $this->optionAttributes;
+	}
+}

--- a/app/Components/OptGroup.php
+++ b/app/Components/OptGroup.php
@@ -1,0 +1,20 @@
+<?php
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Jan Tojnar
+
+declare(strict_types=1);
+
+namespace App\Components;
+
+use App\Locale\Translated;
+use Contributte\Translation\Wrappers\NotTranslate;
+
+final class OptGroup {
+	public function __construct(
+		public readonly string|Translated|NotTranslate $label,
+		/** @var array<string, string|Translated|NotTranslate> */
+		public readonly array $options,
+	) {
+	}
+}

--- a/app/Locale/Translated.php
+++ b/app/Locale/Translated.php
@@ -1,0 +1,12 @@
+<?php
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Jan Tojnar
+
+declare(strict_types=1);
+
+namespace App\Locale;
+
+interface Translated {
+	public function getMessage(string $locale): string;
+}

--- a/app/Locale/Translator.php
+++ b/app/Locale/Translator.php
@@ -1,0 +1,27 @@
+<?php
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2022 Jan Tojnar
+
+declare(strict_types=1);
+
+namespace App\Locale;
+
+use Contributte\Translation\Translator as ContributeTranslator;
+
+class Translator extends ContributeTranslator {
+	/**
+	 * @param mixed $message
+	 * @param mixed ...$parameters
+	 */
+	public function translate(
+		$message,
+		...$parameters
+	): string {
+		if ($message instanceof Translated) {
+			return $message->getMessage($this->getLocale());
+		}
+
+		return parent::translate($message, ...$parameters);
+	}
+}

--- a/app/config/common.neon
+++ b/app/config/common.neon
@@ -73,6 +73,7 @@ services:
 			- addFilter(wrapInParagraphs, @App\Templates\Filters\WrapInParagraphsFilter)
 
 translation:
+	translatorFactory: App\Locale\Translator
 	loaders:
 		neon: App\Helpers\NeonIntlLoader
 	localeResolvers:


### PR DESCRIPTION
In addition to predefined strings that are localized in translation files, the system allows user to define new form fields in the config, where they can be also conveniently translated.

While we could create a custom loader that would extract the translations from the config and then use string message ids to let the `Translator` look up translated messages in the catalogue, we would need to maintain the loader and ensure that the message ids match and have no conflicts.

This patch chooses an easier way of using a wrapper holding all available translations of a message, which our `Translator` will then unpack based on the current locale.

Unfortunately, using the wrapper is not possible in some places (e.g. for `optgroup` labels in `Nette\Forms\Controls\SelectBox`).
