### PR TITLE
Generate QR code for quick payment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ Each minor release (or even commit in the repository) is generally considered a 
 - Invoice lists issue date.
 - Support allowing partially filled placeholder team members.
 - Validate bank account number when provided.
+- Generate QR code for quick payment (requires `gd` extension).
 
 ### Bugs fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Each minor release (or even commit in the repository) is generally considered a 
 - Report config errors earlier.
 - Invoice lists issue date.
 - Support allowing partially filled placeholder team members.
+- Validate bank account number when provided.
 
 ### Bugs fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ Each minor release (or even commit in the repository) is generally considered a 
 
 ### Bugs fixed
 
--
+- `accountNumber` field is now looked for under `parameters` as documented.
 
 ### Other changes
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Entry registration system for [Rogaining](http://en.wikipedia.org/wiki/Rogaining
 
 ## Requirements
 
-- PHP 8.3 or newer with `intl` extension
+- PHP 8.3 or newer with `intl` and `gd` extensions
 - MySQL or other similar database
 - composer dependencies (included in the bundle)
 - npm dependencies (included in the bundle)

--- a/app/Config/common.neon
+++ b/app/Config/common.neon
@@ -55,6 +55,7 @@ orm:
 services:
 	- App\Helpers\EmailFactory(%appDir%)
 	- App\Helpers\Parameters(%parameters%)
+	- App\Helpers\SpaydQrGenerator
 	- App\Model\Configuration\Entries::from(%entries%)
 	- App\Model\TeamManager(%adminPassword%)
 	- App\Forms\FormFactory

--- a/app/Helpers/Parameters.php
+++ b/app/Helpers/Parameters.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace App\Helpers;
 
 final class Parameters {
+	public readonly ?string $accountNumber;
+
 	public function __construct(
 		private readonly array $parameters,
 	) {
+		$this->accountNumber = $parameters['accountNumber'] ?? null;
 	}
 
 	/**

--- a/app/Helpers/Parameters.php
+++ b/app/Helpers/Parameters.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace App\Helpers;
 
+use App\Model\Configuration\Helpers;
+use Rikudou\Iban\Iban\IbanInterface;
+
 final class Parameters {
 	public readonly ?string $accountNumber;
+	public readonly ?IbanInterface $accountNumberIban;
 
 	public function __construct(
 		private readonly array $parameters,
 	) {
 		$this->accountNumber = $parameters['accountNumber'] ?? null;
+		$this->accountNumberIban = Helpers::parseAccountNumber($this->accountNumber);
 	}
 
 	/**

--- a/app/Helpers/SpaydBuilder.php
+++ b/app/Helpers/SpaydBuilder.php
@@ -1,0 +1,66 @@
+<?php
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Jan Tojnar
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+use Money\Currencies\ISOCurrencies;
+use Money\Formatter\DecimalMoneyFormatter;
+use Money\Money;
+use Nette\Utils\Strings;
+use Rikudou\Iban\Iban\IbanInterface;
+
+/**
+ * Builds a Short Payment Descriptor string.
+ *
+ * @see https://en.wikipedia.org/wiki/Short_Payment_Descriptor
+ * @see https://qr-platba.cz/
+ */
+final readonly class SpaydBuilder {
+	/**
+	 * Generates payment instructions in <> format.
+	 */
+	public static function make(
+		IbanInterface $accountNumber,
+		Money $amount,
+		?string $message = null,
+		?string $variableSymbol = null,
+	): string {
+		return 'SPD*1.0*'
+			. self::keyVal('ACC', $accountNumber->asString())
+			. self::amount($amount)
+			. ($message !== null ? self::message($message) : '')
+			. ($variableSymbol !== null ? self::keyVal('X-VS', $variableSymbol) : '');
+	}
+
+	private static function amount(Money $amount): string {
+		$currencies = new ISOCurrencies();
+		$moneyFormatter = new DecimalMoneyFormatter($currencies);
+		$value = $moneyFormatter->format($amount);
+
+		return self::keyVal('AM', $value);
+	}
+
+	/** For simplicity, we are going to convert the string to ASCII and get rid of all special characters. */
+	private static function message(string $message): string {
+		$message = Strings::webalize($message, ' ');
+		$message = trim($message);
+
+		return self::keyVal('MSG', $message);
+	}
+
+	private static function keyVal(string $key, string $value): string {
+		return $key . ':' . self::escapeValue($value) . '*';
+	}
+
+	/** Escapes a value part of key-value pair. */
+	private static function escapeValue(string $value): string {
+		$value = trim($value);
+		$value = str_replace('*', '%2A', $value);
+
+		return $value;
+	}
+}

--- a/app/Helpers/SpaydQrGenerator.php
+++ b/app/Helpers/SpaydQrGenerator.php
@@ -1,0 +1,66 @@
+<?php
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Jan Tojnar
+
+declare(strict_types=1);
+
+namespace App\Helpers;
+
+use BaconQrCode\Renderer\GDLibRenderer;
+use BaconQrCode\Writer;
+use Money\Money;
+use Nette\Utils\FileSystem;
+use Rikudou\Iban\Iban\IbanInterface;
+
+/**
+ * Generates payment QR code in Short Payment Descriptor format.
+ *
+ * @see https://en.wikipedia.org/wiki/Short_Payment_Descriptor
+ * @see https://qr-platba.cz/
+ */
+final readonly class SpaydQrGenerator {
+	public function __construct(
+		private Parameters $parameters,
+	) {
+	}
+
+	/**
+	 * @return string FS path where the generated images will be stored
+	 */
+	public function getStoragePath(): string {
+		return $this->parameters->getTempDir() . '/qrcodes';
+	}
+
+	/**
+	 * Generates a payment QR code and stores it as PNG file in the storage directory.
+	 *
+	 * @return string the file name of the generated image
+	 */
+	public function generate(
+		IbanInterface $accountNumber,
+		Money $amount,
+		string $eventName,
+		int $teamId,
+	): string {
+		$renderer = new GDLibRenderer(400);
+
+		$writer = new Writer($renderer);
+
+		$spd = SpaydBuilder::make(
+			accountNumber: $accountNumber,
+			amount: $amount,
+			message: $eventName,
+			variableSymbol: (string) $teamId,
+		);
+
+		$directory = $this->getStoragePath();
+		$filename = 'payment-' . $teamId . '.png';
+		$path = $directory . '/' . $filename;
+
+		FileSystem::createDir($directory);
+		$writer->writeFile($spd, $path);
+
+		return $filename;
+	}
+}

--- a/app/Model/Configuration/Entries.php
+++ b/app/Model/Configuration/Entries.php
@@ -24,7 +24,6 @@ final class Entries {
 		public readonly DateTimeImmutable $eventDate,
 		public readonly bool $allowLateRegistrationsByEmail,
 		public readonly int $recommendedCardCapacity,
-		public readonly ?string $accountNumber,
 		public readonly Fees $fees,
 		public readonly CategoryData $categories,
 		/** @var array<string, Field> */
@@ -62,7 +61,6 @@ final class Entries {
 			eventDate: $eventDate,
 			allowLateRegistrationsByEmail: $entries['allowLateRegistrationsByEmail'] ?? false,
 			recommendedCardCapacity: $entries['recommendedCardCapacity'] ?? 0,
-			accountNumber: $entries['accountNumber'] ?? null,
 			fees: $fees,
 			categories: CategoryData::from(
 				$entries['categories'] ?? [],

--- a/app/Presenters/CommunicationPresenter.php
+++ b/app/Presenters/CommunicationPresenter.php
@@ -293,7 +293,7 @@ final class CommunicationPresenter extends BasePresenter {
 			'message.latte',
 			new App\Templates\Mail\Message(
 				// Define variables for use in the e-mail template.
-				accountNumber: $this->entries->accountNumber,
+				accountNumber: $this->parameters->accountNumber,
 				eventName: $eventName = $this->parameters->getSiteTitle($this->locale)
 					?? $this->parameters->getSiteTitle($this->translator->getDefaultLocale())
 					?? throw new \PHPStan\ShouldNotHappenException(),

--- a/app/Presenters/CommunicationPresenter.php
+++ b/app/Presenters/CommunicationPresenter.php
@@ -294,6 +294,7 @@ final class CommunicationPresenter extends BasePresenter {
 			new App\Templates\Mail\Message(
 				// Define variables for use in the e-mail template.
 				accountNumber: $this->parameters->accountNumber,
+				accountNumberIban: $this->parameters->accountNumberIban !== null ? $this->parameters->accountNumberIban->asString() : null,
 				eventName: $eventName = $this->parameters->getSiteTitle($this->locale)
 					?? $this->parameters->getSiteTitle($this->translator->getDefaultLocale())
 					?? throw new \PHPStan\ShouldNotHappenException(),

--- a/app/Presenters/TeamPresenter.php
+++ b/app/Presenters/TeamPresenter.php
@@ -653,7 +653,7 @@ final class TeamPresenter extends BasePresenter {
 					$mtemplate->setFile($mailTemplatePath);
 
 					// Define variables for use in the e-mail template.
-					$mtemplate->accountNumber = $this->entries->accountNumber;
+					$mtemplate->accountNumber = $this->parameters->accountNumber;
 					$mtemplate->eventName =
 						$this->parameters->getSiteTitle($this->locale)
 						?? $this->parameters->getSiteTitle($this->translator->getDefaultLocale());

--- a/app/Presenters/TeamPresenter.php
+++ b/app/Presenters/TeamPresenter.php
@@ -654,6 +654,7 @@ final class TeamPresenter extends BasePresenter {
 
 					// Define variables for use in the e-mail template.
 					$mtemplate->accountNumber = $this->parameters->accountNumber;
+					$mtemplate->accountNumberIban = $this->parameters->accountNumberIban !== null ? $this->parameters->accountNumberIban->asString() : null;
 					$mtemplate->eventName =
 						$this->parameters->getSiteTitle($this->locale)
 						?? $this->parameters->getSiteTitle($this->translator->getDefaultLocale());

--- a/app/Templates/Mail/Message.php
+++ b/app/Templates/Mail/Message.php
@@ -12,6 +12,7 @@ use Nextras\Orm\Relationships\OneHasMany;
 final class Message {
 	public function __construct(
 		public ?string $accountNumber,
+		public ?string $accountNumberIban,
 		public string $eventName,
 		public string $eventNameShort,
 		public string $dateFormat,

--- a/app/Templates/Mail/verification.cs.latte
+++ b/app/Templates/Mail/verification.cs.latte
@@ -13,6 +13,12 @@
 
 {block payment}
 <p n:ifset="$accountNumber">Po zaplacení částky <strong>{$invoice->getTotal()|price}</strong> s variabilním symbolem <strong>{$id}</strong> na účet číslo <strong>{$accountNumber}</strong> bude přihláška plně akceptována.</p>
+
+{ifset $qrCode}
+<p>Platbu je možné provést také pomocí následujícího QR kódu:</p>
+
+{$qrCode}
+{/ifset}
 {/block}
 
 <p>V případě jakýchkoli problémů s přihláškou pište na e-mail <a href="mailto:{$organiserMail}">{$organiserMail}</a>.</p>

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
 		"nextras/forms-rendering": "@dev",
 		"nextras/orm": "^5.0",
 		"pelago/emogrifier": "^7.0",
+		"rikudou/iban": "^1.3",
 		"tracy/tracy": "~2.6"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,10 @@
 	],
 	"require": {
 		"php": ">= 8.3",
+		"ext-gd": "*",
 		"ext-intl": "*",
 		"68publishers/asset": "^3.3",
+		"bacon/bacon-qr-code": "^3.0",
 		"contributte/mail": "^0.7.0",
 		"contributte/translation": "^2.0",
 		"kdyby/forms-replicator": "^2.0.0",

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
 	],
 	"require": {
 		"php": ">= 8.3",
+		"ext-intl": "*",
 		"68publishers/asset": "^3.3",
 		"contributte/mail": "^0.7.0",
 		"contributte/translation": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91dcae60c7849d29bc25ce0c738ca671",
+    "content-hash": "153b29b68c5dbf9a4e6f9ef933a14717",
     "packages": [
         {
             "name": "68publishers/asset",
@@ -2058,6 +2058,66 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/2.0.0"
             },
             "time": "2024-10-13T11:29:49+00:00"
+        },
+        {
+            "name": "rikudou/iban",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/RikudouSage/IBAN.git",
+                "reference": "7fe69bf9274792c37d5a8d9d38ef5cb000f8377a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/RikudouSage/IBAN/zipball/7fe69bf9274792c37d5a8d9d38ef5cb000f8377a",
+                "reference": "7fe69bf9274792c37d5a8d9d38ef5cb000f8377a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 | ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpstan/phpstan": "^0.12.63",
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Rikudou\\Iban\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "WTFPL"
+            ],
+            "authors": [
+                {
+                    "name": "Dominik Chrástecký",
+                    "email": "dominik@chrastecky.cz"
+                }
+            ],
+            "description": "Library for working with IBANs",
+            "homepage": "https://github.com/RikudouSage/IBAN",
+            "keywords": [
+                "IBAN"
+            ],
+            "support": {
+                "issues": "https://github.com/RikudouSage/IBAN/issues",
+                "source": "https://github.com/RikudouSage/IBAN/tree/v1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://ko-fi.com/dominik_ch",
+                    "type": "ko_fi"
+                },
+                {
+                    "url": "https://liberapay.com/dominik_ch",
+                    "type": "liberapay"
+                }
+            ],
+            "time": "2023-09-11T07:54:00+00:00"
         },
         {
             "name": "sabberworm/php-css-parser",
@@ -5502,7 +5562,7 @@
     "platform": {
         "php": ">= 8.3"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.3.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "153b29b68c5dbf9a4e6f9ef933a14717",
+    "content-hash": "6d186b543dd666d3ef9477ca3a8e16e1",
     "packages": [
         {
             "name": "68publishers/asset",
@@ -66,6 +66,60 @@
                 "source": "https://github.com/68publishers/asset/tree/v3.3.4"
             },
             "time": "2024-08-05T23:21:30+00:00"
+        },
+        {
+            "name": "bacon/bacon-qr-code",
+            "version": "v3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Bacon/BaconQrCode.git",
+                "reference": "f9cc1f52b5a463062251d666761178dbdb6b544f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/f9cc1f52b5a463062251d666761178dbdb6b544f",
+                "reference": "f9cc1f52b5a463062251d666761178dbdb6b544f",
+                "shasum": ""
+            },
+            "require": {
+                "dasprid/enum": "^1.0.3",
+                "ext-iconv": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "phly/keep-a-changelog": "^2.12",
+                "phpunit/phpunit": "^10.5.11 || 11.0.4",
+                "spatie/phpunit-snapshot-assertions": "^5.1.5",
+                "squizlabs/php_codesniffer": "^3.9"
+            },
+            "suggest": {
+                "ext-imagick": "to generate QR code images"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "BaconQrCode\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "BaconQrCode is a QR code generator for PHP.",
+            "homepage": "https://github.com/Bacon/BaconQrCode",
+            "support": {
+                "issues": "https://github.com/Bacon/BaconQrCode/issues",
+                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.0.1"
+            },
+            "time": "2024-10-01T13:55:55+00:00"
         },
         {
             "name": "contributte/mail",
@@ -230,6 +284,56 @@
                 }
             ],
             "time": "2024-03-20T10:14:53+00:00"
+        },
+        {
+            "name": "dasprid/enum",
+            "version": "1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DASPRiD/Enum.git",
+                "reference": "8dfd07c6d2cf31c8da90c53b83c026c7696dda90"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DASPRiD/Enum/zipball/8dfd07c6d2cf31c8da90c53b83c026c7696dda90",
+                "reference": "8dfd07c6d2cf31c8da90c53b83c026c7696dda90",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1 <9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DASPRiD\\Enum\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Ben Scholzen 'DASPRiD'",
+                    "email": "mail@dasprids.de",
+                    "homepage": "https://dasprids.de/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP 7.1 enum implementation",
+            "keywords": [
+                "enum",
+                "map"
+            ],
+            "support": {
+                "issues": "https://github.com/DASPRiD/Enum/issues",
+                "source": "https://github.com/DASPRiD/Enum/tree/1.0.6"
+            },
+            "time": "2024-08-09T14:30:48+00:00"
         },
         {
             "name": "kdyby/forms-replicator",

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,8 @@ siteTitle:
 
 This is the bank account number to be listed in payment instructions in the Czech e-mail the team receives after registration. (Unless the message text is [overridden](customizing-emails.md).)
 
+This can be in [Czech national format](https://www.cnb.cz/cs/platebni-styk/iban/iban-mezinarodni-format-cisla-uctu/) or in [IBAN format](https://en.wikipedia.org/wiki/International_Bank_Account_Number).
+
 ```neon
 accountNumber: '000000-0000000000/0000'
 ```

--- a/tests/Model/Configuration/AccountNumberTest.phpt
+++ b/tests/Model/Configuration/AccountNumberTest.phpt
@@ -1,0 +1,74 @@
+<?php
+
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Jan Tojnar
+
+declare(strict_types=1);
+
+namespace App\Tests\Model\Configuration;
+
+use App\Model\Configuration\Helpers;
+use App\Model\Configuration\InvalidConfigurationException;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+class AccountNumberTest extends TestCase {
+	public function testNull(): void {
+		$iban = Helpers::parseAccountNumber(null);
+		Assert::same(null, $iban);
+	}
+
+	public function testCzech(): void {
+		$iban = Helpers::parseAccountNumber('281115217/0300');
+		Assert::same('CZ9103000000000281115217', $iban?->asString());
+	}
+
+	public function testCzechWithPrefix(): void {
+		$iban = Helpers::parseAccountNumber('21012-27924051/0710');
+		Assert::same('CZ4707100210120027924051', $iban?->asString());
+	}
+
+	public function testCzechInvalid(): void {
+		Assert::exception(
+			function(): void {
+				Helpers::parseAccountNumber('123456/1234');
+			},
+			InvalidConfigurationException::class,
+			'Invalid account number.',
+		);
+	}
+
+	public function testIbanCzech(): void {
+		$iban = Helpers::parseAccountNumber('CZ5530300000001325090010');
+		Assert::same('CZ5530300000001325090010', $iban?->asString());
+	}
+
+	public function testIbanHungarian(): void {
+		$iban = Helpers::parseAccountNumber('HU38109180010000011721150000');
+		Assert::same('HU38109180010000011721150000', $iban?->asString());
+	}
+
+	public function testIbanInvalid(): void {
+		Assert::exception(
+			function(): void {
+				Helpers::parseAccountNumber('CZ1327000000000500114005');
+			},
+			InvalidConfigurationException::class,
+			'Invalid account number.',
+		);
+	}
+
+	public function testInvalid(): void {
+		Assert::exception(
+			function(): void {
+				Helpers::parseAccountNumber('foo');
+			},
+			InvalidConfigurationException::class,
+			'Invalid account number.',
+		);
+	}
+}
+
+(new AccountNumberTest())->run();


### PR DESCRIPTION
This should make payments much more convenient for mobile-first crowd.

Currently, this is only supported in the initial mail, not in `CommunicationPresenter`.

I manually verified a generated SPD string using https://qr-platba.cz/pro-vyvojare/validator/