### PR TITLE
Teams/lists: Fix category filter with All

### DIFF
--- a/app/Presenters/TeamPresenter.php
+++ b/app/Presenters/TeamPresenter.php
@@ -786,12 +786,14 @@ final class TeamPresenter extends BasePresenter {
 	private function filterRedir(Nette\Forms\Form $form): void {
 		$parameters = [];
 
-		if ($this->request->getQuery('category') !== null) {
-			$parameters['category'] = $this->request->getQuery('category');
+		$category = $this->request->getQuery('category');
+		if ($category !== null && $category !== '') {
+			$parameters['category'] = $category;
 		}
 
-		if ($this->request->getQuery('status') !== null) {
-			$parameters['status'] = $this->request->getQuery('status');
+		$status = $this->request->getQuery('status');
+		if ($status !== null && $status !== '') {
+			$parameters['status'] = $status;
 		}
 
 		if (\count($parameters) === 0) {


### PR DESCRIPTION
All has empty string as a value.

This regressed in fefa7ac17b298a73be6bca5105fca263a7f7ca7d
